### PR TITLE
Exercism report update

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mpizenberg/elm-test-runner",
     "summary": "Helper package to run tests and report results",
     "license": "BSD-3-Clause",
-    "version": "4.0.4",
+    "version": "4.0.5",
     "exposed-modules": [
         "ElmTestRunner.Failure",
         "ElmTestRunner.Reporter",

--- a/src/ElmTestRunner/Reporter/Exercism.elm
+++ b/src/ElmTestRunner/Reporter/Exercism.elm
@@ -33,12 +33,13 @@ implementation =
 
 
 -- {
---   "version": 2,
+--   "version": 3,
 --   "status": "fail",
 --   "message": null,
 --   "tests": [
 --     {
 --       "name": "Test that the thing works",
+--       "task_id": 1,
 --       "status": "fail",
 --       "message": "Expected 42 but got 123123",
 --       "output": "Debugging information output by the user",

--- a/src/ElmTestRunner/Reporter/Exercism.elm
+++ b/src/ElmTestRunner/Reporter/Exercism.elm
@@ -3,7 +3,7 @@ module ElmTestRunner.Reporter.Exercism exposing (implementation)
 {-| Implementation of a reporter following the spec
 for exercism tests runners.
 
-<https://github.com/exercism/v3-docs/blob/master/anatomy/track-tooling/test-runners/interface.md>
+<https://github.com/exercism/docs/blob/main/building/tooling/test-runners/interface.md>
 
 @docs implementation
 

--- a/src/ElmTestRunner/Reporter/Exercism.elm
+++ b/src/ElmTestRunner/Reporter/Exercism.elm
@@ -55,7 +55,7 @@ summary kindOrErr results =
         Err err ->
             Encode.encode 2
                 (Encode.object
-                    [ ( "version", Encode.int 2 )
+                    [ ( "version", Encode.int 3 )
                     , ( "status", Encode.string "error" )
                     , ( "message", Encode.string err )
                     ]
@@ -71,7 +71,7 @@ summary kindOrErr results =
             in
             Encode.encode 2
                 (Encode.object
-                    [ ( "version", Encode.int 2 )
+                    [ ( "version", Encode.int 3 )
                     , ( "status", Encode.string status )
                     , ( "tests", Encode.array encodeExercismResult tests )
                     ]


### PR DESCRIPTION
We add a `task_id` field in the exercism report output. The `name` field was updated to only report the last describe component.