### PR TITLE
Improve console messages

### DIFF
--- a/src/ElmTestRunner/Reporter/ConsoleColor.elm
+++ b/src/ElmTestRunner/Reporter/ConsoleColor.elm
@@ -35,9 +35,14 @@ implementation useColor options =
 -}
 onBegin : { seed : Int, fuzzRuns : Int, verbosity : Int } -> Int -> Maybe Text
 onBegin { seed, fuzzRuns } testsCount =
-    "Running "
-        ++ String.fromInt testsCount
-        ++ " tests. To reproduce these results later, run:\nelm-test-rs --seed "
+    (if testsCount == 1 then
+        "Running 1 test. To reproduce these results later, run:\nelm-test-rs --seed "
+
+     else
+        "Running "
+            ++ String.fromInt testsCount
+            ++ " tests. To reproduce these results later, run:\nelm-test-rs --seed "
+    )
         ++ String.fromInt seed
         ++ " --fuzz "
         ++ String.fromInt fuzzRuns

--- a/src/ElmTestRunner/Reporter/ConsoleColor.elm
+++ b/src/ElmTestRunner/Reporter/ConsoleColor.elm
@@ -35,14 +35,12 @@ implementation useColor options =
 -}
 onBegin : { seed : Int, fuzzRuns : Int, verbosity : Int } -> Int -> Maybe Text
 onBegin { seed, fuzzRuns } testsCount =
-    """
-Running {{ testsCount }} tests. To reproduce these results later,
-run elm-test-rs with --seed {{ seed }} and --fuzz {{ fuzzRuns }}
-
-"""
-        |> String.replace "{{ testsCount }}" (String.fromInt testsCount)
-        |> String.replace "{{ seed }}" (String.fromInt seed)
-        |> String.replace "{{ fuzzRuns }}" (String.fromInt fuzzRuns)
+    "Running "
+        ++ String.fromInt testsCount
+        ++ " tests. To reproduce these results later, run:\nelm-test-rs --seed "
+        ++ String.fromInt seed
+        ++ " --fuzz "
+        ++ String.fromInt fuzzRuns
         |> plain
         |> Just
 

--- a/src/ElmTestRunner/Reporter/ConsoleDebug.elm
+++ b/src/ElmTestRunner/Reporter/ConsoleDebug.elm
@@ -27,13 +27,12 @@ implementation options =
 
 onBegin : { seed : Int, fuzzRuns : Int } -> Int -> Maybe String
 onBegin { seed, fuzzRuns } testsCount =
-    """
-Running {{ testsCount }} tests. To reproduce these results later,
-run elm-test-rs with --seed {{ seed }} and --fuzz {{ fuzzRuns }}.
-"""
-        |> String.replace "{{ testsCount }}" (String.fromInt testsCount)
-        |> String.replace "{{ seed }}" (String.fromInt seed)
-        |> String.replace "{{ fuzzRuns }}" (String.fromInt fuzzRuns)
+    "Running "
+        ++ String.fromInt testsCount
+        ++ " tests. To reproduce these results later, run:\nelm-test-rs --seed "
+        ++ String.fromInt seed
+        ++ " --fuzz "
+        ++ String.fromInt fuzzRuns
         |> Just
 
 

--- a/src/ElmTestRunner/Reporter/ConsoleDebug.elm
+++ b/src/ElmTestRunner/Reporter/ConsoleDebug.elm
@@ -27,9 +27,14 @@ implementation options =
 
 onBegin : { seed : Int, fuzzRuns : Int } -> Int -> Maybe String
 onBegin { seed, fuzzRuns } testsCount =
-    "Running "
-        ++ String.fromInt testsCount
-        ++ " tests. To reproduce these results later, run:\nelm-test-rs --seed "
+    (if testsCount == 1 then
+        "Running 1 test. To reproduce these results later, run:\nelm-test-rs --seed "
+
+     else
+        "Running "
+            ++ String.fromInt testsCount
+            ++ " tests. To reproduce these results later, run:\nelm-test-rs --seed "
+    )
         ++ String.fromInt seed
         ++ " --fuzz "
         ++ String.fromInt fuzzRuns


### PR DESCRIPTION
Hi, thanks for making `elm-test-rs`!
I fixed a minor annoyance in the console logs. Now, the message to replicate the tests is copy-pasteable.

Before:
```
Running 1 tests. To reproduce these results later,
run elm-test-rs with --seed 597517184 and --fuzz 100
```
After:
```
Running 1 test. To reproduce these results later, run:
elm-test-rs --seed 597517184 --fuzz 100
```

I hope this is helpful! 😁 