### PR TITLE
Fix O(N²) blowup in character-level diff for large dissimilar strings

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mpizenberg/elm-test-runner",
     "summary": "Helper package to run tests and report results",
     "license": "BSD-3-Clause",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "exposed-modules": [
         "ElmTestRunner.Failure",
         "ElmTestRunner.Reporter",

--- a/src/ElmTestRunner/Vendor/ConsoleFormat.elm
+++ b/src/ElmTestRunner/Vendor/ConsoleFormat.elm
@@ -124,21 +124,27 @@ highlightEqual expected actual =
             highlightedActual =
                 Highlightable.diffLists actualChars expectedChars
                     |> List.map (Highlightable.map String.fromChar)
-
-            plainCharCount =
-                highlightedExpected
-                    |> List.filter (not << isHighlighted)
-                    |> List.length
         in
-        if edgeCount highlightedActual > plainCharCount || edgeCount highlightedExpected > plainCharCount then
-            -- Large number of small highlighted blocks. Diff is too messy to be useful.
+        if List.length highlightedExpected /= String.length expected then
+            -- Diff bailed out (too many edits). Skip highlighting.
             Nothing
 
         else
-            Just
-                ( highlightedExpected
-                , highlightedActual
-                )
+            let
+                plainCharCount =
+                    highlightedExpected
+                        |> List.filter (not << isHighlighted)
+                        |> List.length
+            in
+            if edgeCount highlightedActual > plainCharCount || edgeCount highlightedExpected > plainCharCount then
+                -- Large number of small highlighted blocks. Diff is too messy to be useful.
+                Nothing
+
+            else
+                Just
+                    ( highlightedExpected
+                    , highlightedActual
+                    )
 
 
 isFloat : String -> Bool

--- a/src/ElmTestRunner/Vendor/Diff.elm
+++ b/src/ElmTestRunner/Vendor/Diff.elm
@@ -81,7 +81,20 @@ type BugReport
 -}
 diff : List a -> List a -> List (Change a)
 diff a b =
-    case testDiff a b of
+    diffWithMaxEdits maxEditsDefault a b
+
+
+{-| Maximum number of edits (P in the O(NP) algorithm) before bailing out.
+This prevents O(N²) blowups on large, very dissimilar inputs.
+-}
+maxEditsDefault : Int
+maxEditsDefault =
+    200
+
+
+diffWithMaxEdits : Int -> List a -> List a -> List (Change a)
+diffWithMaxEdits maxEdits a b =
+    case testDiff maxEdits a b of
         Ok changes ->
             changes
 
@@ -92,8 +105,8 @@ diff a b =
 {-| Test the algolithm itself.
 If it returns Err, it should be a bug.
 -}
-testDiff : List a -> List a -> Result BugReport (List (Change a))
-testDiff a b =
+testDiff : Int -> List a -> List a -> Result BugReport (List (Change a))
+testDiff maxEdits a b =
     let
         arrA =
             Array.fromList a
@@ -116,9 +129,7 @@ testDiff a b =
             \y -> Array.get (y - 1) arrB
 
         path =
-            -- Is there any case ond is needed?
-            -- ond getA getB m n
-            onp getA getB m n
+            onp maxEdits getA getB m n
     in
     makeChanges getA getB path
 
@@ -191,8 +202,8 @@ makeChangesHelp changes getA getB ( x, y ) path =
 -- Wu's O(NP) algorithm (http://myerslab.mpi-cbg.de/wp-content/uploads/2014/06/np_diff.pdf)
 
 
-onp : (Int -> Maybe a) -> (Int -> Maybe a) -> Int -> Int -> List ( Int, Int )
-onp getA getB m n =
+onp : Int -> (Int -> Maybe a) -> (Int -> Maybe a) -> Int -> Int -> List ( Int, Int )
+onp maxEdits getA getB m n =
     let
         v =
             Array.initialize (m + n + 1) (always [])
@@ -200,33 +211,39 @@ onp getA getB m n =
         delta =
             n - m
     in
-    onpLoopP (snake getA getB) delta m 0 v
+    onpLoopP maxEdits (snake getA getB) delta m 0 v
 
 
 onpLoopP :
-    (Int -> Int -> List ( Int, Int ) -> ( List ( Int, Int ), Bool ))
+    Int
+    -> (Int -> Int -> List ( Int, Int ) -> ( List ( Int, Int ), Bool ))
     -> Int
     -> Int
     -> Int
     -> Array (List ( Int, Int ))
     -> List ( Int, Int )
-onpLoopP snake_ delta offset p v =
-    let
-        ks =
-            if delta > 0 then
-                List.reverse (List.range (delta + 1) (delta + p))
-                    ++ List.range -p delta
+onpLoopP maxEdits snake_ delta offset p v =
+    if p > maxEdits then
+        -- Too many edits; bail out to avoid O(N²) blowup.
+        []
 
-            else
-                List.reverse (List.range (delta + 1) p)
-                    ++ List.range (-p + delta) delta
-    in
-    case onpLoopK snake_ offset ks v of
-        Found path ->
-            path
+    else
+        let
+            ks =
+                if delta > 0 then
+                    reversePrepend (List.range (delta + 1) (delta + p))
+                        (List.range -p delta)
 
-        Continue v_ ->
-            onpLoopP snake_ delta offset (p + 1) v_
+                else
+                    reversePrepend (List.range (delta + 1) p)
+                        (List.range (-p + delta) delta)
+        in
+        case onpLoopK snake_ offset ks v of
+            Found path ->
+                path
+
+            Continue v_ ->
+                onpLoopP maxEdits snake_ delta offset (p + 1) v_
 
 
 onpLoopK :
@@ -319,3 +336,16 @@ snake getA getB nextX nextY path =
 
         _ ->
             ( path, False )
+
+
+{-| Prepend elements from the first list onto the second, in reverse order.
+Equivalent to `List.reverse xs ++ ys` but in a single pass.
+-}
+reversePrepend : List a -> List a -> List a
+reversePrepend xs ys =
+    case xs of
+        [] ->
+            ys
+
+        x :: rest ->
+            reversePrepend rest (x :: ys)

--- a/src/ElmTestRunner/Vendor/Highlightable.elm
+++ b/src/ElmTestRunner/Vendor/Highlightable.elm
@@ -25,9 +25,32 @@ resolve { fromHighlighted, fromPlain } highlightable =
 
 diffLists : List a -> List a -> List (Highlightable a)
 diffLists expected actual =
-    -- TODO make sure this looks reasonable for multiline strings
-    Diff.diff expected actual
-        |> List.concatMap fromDiff
+    let
+        ( prefix, restExpected, restActual ) =
+            trimPrefix [] expected actual
+
+        ( suffixRev, midExpectedRev, midActualRev ) =
+            trimPrefix [] (List.reverse restExpected) (List.reverse restActual)
+
+        middle =
+            Diff.diff (List.reverse midExpectedRev) (List.reverse midActualRev)
+                |> List.concatMap fromDiff
+    in
+    List.map Plain prefix ++ middle ++ List.map Plain (List.reverse suffixRev)
+
+
+trimPrefix : List a -> List a -> List a -> ( List a, List a, List a )
+trimPrefix acc a b =
+    case ( a, b ) of
+        ( x :: restA, y :: restB ) ->
+            if x == y then
+                trimPrefix (x :: acc) restA restB
+
+            else
+                ( List.reverse acc, a, b )
+
+        _ ->
+            ( List.reverse acc, a, b )
 
 
 map : (a -> b) -> Highlightable a -> Highlightable b


### PR DESCRIPTION
### Problem

When `Expect.equal` fails on two large, dissimilar strings, the reporter's character-level diff takes several seconds — even for a single trivial test.

```elm
Test.test "fail" (\_ -> Expect.equal (String.repeat 1000 "a") (String.repeat 1000 "b"))
```

With `elm-test` (node runner), this takes ~3 seconds. With `elm-test-rs`, the same issue exists since the reporter Elm code is vendored from the same source.

### Root cause

`highlightEqual` in `ConsoleFormat.elm` runs Wu's O(NP) diff algorithm **twice** on the full character lists (once per direction). The algorithm's complexity is O((M+N)·P), where P is the number of deletions. For completely dissimilar strings, P ≈ N, making it effectively **O(N²)**.

To make things worse, in this pathological case the result is always discarded by the `edgeCount` check ("diff too messy to be useful"), so the expensive computation is entirely wasted.

### Changes

Three complementary fixes across the vendor modules:

**`Diff.elm` — Bounded edit distance**

Added a `maxEdits` cap (default 200) to the `onpLoopP` loop. When P exceeds this threshold, the algorithm bails out early with an empty path instead of continuing into O(N²) territory. This is the main fix — it turns the worst case from O(N²) into O(N · maxEdits).

Also replaced `List.reverse xs ++ ys` with a single-pass `reversePrepend` helper.

**`Highlightable.elm` — Common prefix/suffix trimming**

`diffLists` now trims matching characters from both ends before invoking the diff. This reduces input size for the common case of mostly-similar strings (e.g. a typo in a long string), where only a small middle section actually differs.

**`ConsoleFormat.elm` — Bail-out detection**

When the diff bails out (highlighted list length doesn't match input length), `highlightEqual` returns `Nothing`, falling back to the plain expected/actual display without highlighting. No change to the module's API or imports.

### Results

Tested with `Expect.equal (String.repeat 1000 "a") (String.repeat 1000 "b")`:

| Metric | Before | After |
|---|---|---|
| Wall time (warm, `time elm-test-rs`) | ~3.6s | ~0.37s |

Character-level highlighting still works correctly for similar strings:

```
                     ▼▼▼
    "the quick brown cat jumps"
    ╷
    │ Expect.equal
    ╵
    "the quick brown fox jumps"
                     ▲▲▲
```

For the pathological case, it now falls back to the plain display (no `▲▼` markers), which is what the old code did too — it just took 3 seconds to reach that conclusion.

### Note

This is the same issue present in the upstream [node-test-runner](https://github.com/rtfeldman/node-test-runner) reporter code, from which these vendor files were originally copied.
